### PR TITLE
Add error handling to Stripe checkout session creation

### DIFF
--- a/js/stripe.js
+++ b/js/stripe.js
@@ -10,26 +10,30 @@ const stripe = Stripe(secrets.key);
 app.use(cors())
 
 app.post('/create-checkout-session', async (req, res) => {
-  const session = await stripe.checkout.sessions.create({
-    payment_method_types: ['card'],
-    line_items: [
-      {
-        price_data: {
-          currency: 'usd',
-          product_data: {
-            name: 'poetry book',
+  try {
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ['card'],
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            product_data: {
+              name: 'poetry book',
+            },
+            unit_amount: 5490,
           },
-          unit_amount: 5490,
+          quantity: 1,
         },
-        quantity: 1,
-      },
-    ],
-    mode: 'payment',
-    success_url: 'https://brsbl.com/pages/success.html',
-    cancel_url: 'https://brsbl.com/pages/book.html'
-  });
+      ],
+      mode: 'payment',
+      success_url: 'https://brsbl.com/pages/success.html',
+      cancel_url: 'https://brsbl.com/pages/book.html'
+    });
 
-  res.json({ id: session.id });
+    res.json({ id: session.id });
+  } catch (error) {
+    res.status(400).json({ error: error.message });
+  }
 });
 
 app.listen(4242, () => console.log(`Listening on port ${4242}!`));


### PR DESCRIPTION
## Summary
- Adds try-catch block to handle errors during Stripe checkout session creation
- Returns HTTP 400 status with error message if session creation fails

## Changes

### Backend
- Wrapped `stripe.checkout.sessions.create` call in a try-catch block
- On success, responds with session ID as before
- On failure, responds with status 400 and JSON error message

## Test plan
- [ ] Test successful checkout session creation returns session ID
- [ ] Test invalid requests or Stripe errors return 400 with error message
- [ ] Verify server does not crash on Stripe API errors

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ac9c0a4e-bee5-4cc0-9927-f53abb697237