### PR TITLE
Add error handling to Stripe checkout session creation

### DIFF
--- a/js/stripe.js
+++ b/js/stripe.js
@@ -10,26 +10,31 @@ const stripe = Stripe(secrets.key);
 app.use(cors())
 
 app.post('/create-checkout-session', async (req, res) => {
-  const session = await stripe.checkout.sessions.create({
-    payment_method_types: ['card'],
-    line_items: [
-      {
-        price_data: {
-          currency: 'usd',
-          product_data: {
-            name: 'poetry book',
+  try {
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ['card'],
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            product_data: {
+              name: 'poetry book',
+            },
+            unit_amount: 5490,
           },
-          unit_amount: 5490,
+          quantity: 1,
         },
-        quantity: 1,
-      },
-    ],
-    mode: 'payment',
-    success_url: 'https://brsbl.com/pages/success.html',
-    cancel_url: 'https://brsbl.com/pages/book.html'
-  });
+      ],
+      mode: 'payment',
+      success_url: 'https://brsbl.com/pages/success.html',
+      cancel_url: 'https://brsbl.com/pages/book.html'
+    });
 
-  res.json({ id: session.id });
+    res.json({ id: session.id });
+  } catch (error) {
+    console.error('Stripe error:', error.message);
+    res.status(400).json({ error: error.message });
+  }
 });
 
 app.listen(4242, () => console.log(`Listening on port ${4242}!`));


### PR DESCRIPTION
## Summary
- Adds try-catch block to handle errors during Stripe checkout session creation
- Logs Stripe errors to the console
- Returns error message with HTTP 400 status on failure

## Changes

### Backend Stripe Integration
- Wrapped `stripe.checkout.sessions.create` call in a try-catch block
- On success, returns session ID as JSON
- On error, logs error message and responds with JSON error and status 400

## Test plan
- [x] Verify successful checkout session creation returns session ID
- [x] Simulate Stripe API failure and confirm error is logged and returned with status 400
- [x] Confirm frontend handles error response gracefully

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/db1dcef9-8e25-4e1c-9c9e-7f9f995a96fc