### PR TITLE
Add health check endpoint to Stripe server

### DIFF
--- a/js/stripe.js
+++ b/js/stripe.js
@@ -9,6 +9,10 @@ const stripe = Stripe(secrets.key);
 
 app.use(cors())
 
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok', port: 4242 });
+});
+
 app.post('/create-checkout-session', async (req, res) => {
   const session = await stripe.checkout.sessions.create({
     payment_method_types: ['card'],


### PR DESCRIPTION
## Summary
- Adds a `/health` GET endpoint to the Stripe server
- Endpoint returns a JSON response with status and port information

## Changes

### Backend
- **Health Check Endpoint**: Implemented `/health` route that responds with `{ status: 'ok', port: 4242 }`

## Test plan
- [x] Verified that GET `/health` returns the expected JSON response
- [x] Confirmed no impact on existing Stripe checkout session creation endpoint

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/74e8a6c6-0788-4f48-aab7-1cb86cbd75b4