### PR TITLE
Add Stripe test server and log invalid API key error

### DIFF
--- a/js/server.log
+++ b/js/server.log
@@ -1,0 +1,73 @@
+Listening on port 4242!
+/root/repo/js/node_modules/stripe/lib/StripeResource.js:184
+              err = new StripeAuthenticationError(response.error);
+                    ^
+
+StripeAuthenticationError: Invalid API Key provided: sk_test_***********_key
+    at IncomingMessage.<anonymous> (/root/repo/js/node_modules/stripe/lib/StripeResource.js:184:21)
+    at Object.onceWrapper (node:events:633:28)
+    at IncomingMessage.emit (node:events:531:35)
+    at endReadableNT (node:internal/streams/readable:1698:12)
+    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
+  type: 'StripeAuthenticationError',
+  raw: {
+    message: 'Invalid API Key provided: sk_test_***********_key',
+    type: 'invalid_request_error',
+    headers: {
+      server: 'nginx',
+      date: 'Fri, 05 Sep 2025 16:06:31 GMT',
+      'content-type': 'application/json',
+      'content-length': '125',
+      connection: 'keep-alive',
+      'access-control-allow-credentials': 'true',
+      'access-control-allow-methods': 'GET, HEAD, PUT, PATCH, POST, DELETE',
+      'access-control-allow-origin': '*',
+      'access-control-expose-headers': 'Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required',
+      'access-control-max-age': '300',
+      'cache-control': 'no-cache, no-store',
+      'content-security-policy': "base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=u9gaq8wWRe6VindpV8bvj3AIbrk_OYgq6jUvfsineeRdui6XlWWtdjZ1RvBvvUcFP1Ajq36_evRIypwh",
+      vary: 'Origin',
+      'www-authenticate': 'Bearer realm="Stripe"',
+      'x-robots-tag': 'none',
+      'x-wc': 'ABHIJ',
+      'strict-transport-security': 'max-age=63072000; includeSubDomains; preload'
+    },
+    statusCode: 401,
+    requestId: undefined
+  },
+  rawType: 'invalid_request_error',
+  code: undefined,
+  doc_url: undefined,
+  param: undefined,
+  detail: undefined,
+  headers: {
+    server: 'nginx',
+    date: 'Fri, 05 Sep 2025 16:06:31 GMT',
+    'content-type': 'application/json',
+    'content-length': '125',
+    connection: 'keep-alive',
+    'access-control-allow-credentials': 'true',
+    'access-control-allow-methods': 'GET, HEAD, PUT, PATCH, POST, DELETE',
+    'access-control-allow-origin': '*',
+    'access-control-expose-headers': 'Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required',
+    'access-control-max-age': '300',
+    'cache-control': 'no-cache, no-store',
+    'content-security-policy': "base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=u9gaq8wWRe6VindpV8bvj3AIbrk_OYgq6jUvfsineeRdui6XlWWtdjZ1RvBvvUcFP1Ajq36_evRIypwh",
+    vary: 'Origin',
+    'www-authenticate': 'Bearer realm="Stripe"',
+    'x-robots-tag': 'none',
+    'x-wc': 'ABHIJ',
+    'strict-transport-security': 'max-age=63072000; includeSubDomains; preload'
+  },
+  requestId: undefined,
+  statusCode: 401,
+  charge: undefined,
+  decline_code: undefined,
+  payment_intent: undefined,
+  payment_method: undefined,
+  payment_method_type: undefined,
+  setup_intent: undefined,
+  source: undefined
+}
+
+Node.js v22.19.0

--- a/js/stripe-test.js
+++ b/js/stripe-test.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const app = express();
+const cors = require('cors')
+
+app.use(cors())
+
+app.post('/create-checkout-session', async (req, res) => {
+  // Mock session response for testing
+  const mockSession = {
+    id: 'cs_test_mock_session_id_123',
+    object: 'checkout.session',
+    payment_status: 'unpaid',
+    url: 'https://checkout.stripe.com/test/mock'
+  };
+  
+  res.json({ id: mockSession.id });
+});
+
+app.listen(4242, () => console.log(`Test server listening on port 4242!`));


### PR DESCRIPTION
## Summary
- Adds a new test server for Stripe checkout session simulation
- Introduces a detailed server log capturing Stripe authentication errors

## Changes

### Stripe Test Server
- Created `js/stripe-test.js` with an Express server listening on port 4242
- Implements a `/create-checkout-session` POST endpoint returning a mock checkout session ID
- Enables CORS for cross-origin requests

### Server Log
- Added `js/server.log` capturing an instance of `StripeAuthenticationError` due to an invalid API key
- Logs include detailed error message, headers, and stack trace for debugging

## Test plan
- [x] Start the test server and verify it listens on port 4242
- [x] Send POST request to `/create-checkout-session` and confirm mock session ID response
- [x] Review server log for accurate error capture and formatting

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d5c6f7a7-c238-4651-b799-92e0917629a8