### PR TITLE
Add server log file capturing Stripe authentication error

### DIFF
--- a/js/server.log
+++ b/js/server.log
@@ -1,0 +1,73 @@
+Listening on port 4242!
+/root/repo/js/node_modules/stripe/lib/StripeResource.js:184
+              err = new StripeAuthenticationError(response.error);
+                    ^
+
+StripeAuthenticationError: Invalid API Key provided: sk_test_***********************ting
+    at IncomingMessage.<anonymous> (/root/repo/js/node_modules/stripe/lib/StripeResource.js:184:21)
+    at Object.onceWrapper (node:events:633:28)
+    at IncomingMessage.emit (node:events:531:35)
+    at endReadableNT (node:internal/streams/readable:1698:12)
+    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
+  type: 'StripeAuthenticationError',
+  raw: {
+    message: 'Invalid API Key provided: sk_test_***********************ting',
+    type: 'invalid_request_error',
+    headers: {
+      server: 'nginx',
+      date: 'Mon, 08 Sep 2025 16:04:31 GMT',
+      'content-type': 'application/json',
+      'content-length': '137',
+      connection: 'keep-alive',
+      'access-control-allow-credentials': 'true',
+      'access-control-allow-methods': 'GET, HEAD, PUT, PATCH, POST, DELETE',
+      'access-control-allow-origin': '*',
+      'access-control-expose-headers': 'Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required',
+      'access-control-max-age': '300',
+      'cache-control': 'no-cache, no-store',
+      'content-security-policy': "base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=FxvZp4XAqFw3A9fSha0KPsqIN97OLmZM_2CXQOlXvdvyOqqSR2s1ob1jZkcB2d3g2816QiS1c0GVTRnP",
+      vary: 'Origin',
+      'www-authenticate': 'Bearer realm="Stripe"',
+      'x-robots-tag': 'none',
+      'x-wc': 'ABHIJ',
+      'strict-transport-security': 'max-age=63072000; includeSubDomains; preload'
+    },
+    statusCode: 401,
+    requestId: undefined
+  },
+  rawType: 'invalid_request_error',
+  code: undefined,
+  doc_url: undefined,
+  param: undefined,
+  detail: undefined,
+  headers: {
+    server: 'nginx',
+    date: 'Mon, 08 Sep 2025 16:04:31 GMT',
+    'content-type': 'application/json',
+    'content-length': '137',
+    connection: 'keep-alive',
+    'access-control-allow-credentials': 'true',
+    'access-control-allow-methods': 'GET, HEAD, PUT, PATCH, POST, DELETE',
+    'access-control-allow-origin': '*',
+    'access-control-expose-headers': 'Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required',
+    'access-control-max-age': '300',
+    'cache-control': 'no-cache, no-store',
+    'content-security-policy': "base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=FxvZp4XAqFw3A9fSha0KPsqIN97OLmZM_2CXQOlXvdvyOqqSR2s1ob1jZkcB2d3g2816QiS1c0GVTRnP",
+    vary: 'Origin',
+    'www-authenticate': 'Bearer realm="Stripe"',
+    'x-robots-tag': 'none',
+    'x-wc': 'ABHIJ',
+    'strict-transport-security': 'max-age=63072000; includeSubDomains; preload'
+  },
+  requestId: undefined,
+  statusCode: 401,
+  charge: undefined,
+  decline_code: undefined,
+  payment_intent: undefined,
+  payment_method: undefined,
+  payment_method_type: undefined,
+  setup_intent: undefined,
+  source: undefined
+}
+
+Node.js v22.19.0


### PR DESCRIPTION
## Summary
- Adds a new server log file `js/server.log` to capture runtime logs
- Logs include server start message and detailed Stripe authentication error
- Helps in debugging Stripe API key issues by providing error stack trace and HTTP headers

## Changes

### Logging
- Created `js/server.log` file with 73 lines of log output
- Logs server listening on port 4242
- Captures `StripeAuthenticationError` due to invalid API key with full error details
- Includes HTTP response headers and error metadata for troubleshooting

## Test plan
- [x] Verify server starts and logs "Listening on port 4242!"
- [x] Confirm Stripe authentication error is logged when invalid API key is used
- [x] Check log file contains full error stack and HTTP headers
- [x] Ensure no sensitive API keys are exposed in logs (masked in output)

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/2920f134-8d17-4fc2-9d18-075ceee651d9